### PR TITLE
開発環境の整備

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem "webpacker", "~> 5.0"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
+  gem "pry-byebug"
+  gem "pry-rails"
+  gem "pry-doc"
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem "webpacker", "~> 5.0"
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "pry-byebug"
-  gem "pry-rails"
   gem "pry-doc"
+  gem "pry-rails"
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     erubi (1.10.0)
@@ -101,6 +102,17 @@ GEM
     pluginator (1.5.0)
     pre-commit (0.39.0)
       pluginator (~> 1.5)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    pry-doc (1.1.0)
+      pry (~> 0.11)
+      yard (~> 0.9.11)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (5.3.2)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -203,6 +215,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    yard (0.9.26)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -215,6 +228,9 @@ DEPENDENCIES
   listen (~> 3.3)
   pg (~> 1.1)
   pre-commit
+  pry-byebug
+  pry-doc
+  pry-rails
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)


### PR DESCRIPTION
close #1

## 実装内容
'pry-byebug' , 'pry-rails' , 'pry-doc' のgemを追加して`bundle install`

## 確認内容
gemのインストールを確認


## チェックリスト 
- [x] `rubocop -a` を実行

## 備考
`rubocop -a`の実行時に`routes.rb`に不要な空ブロックがある旨、記載ありましたが、#2でルーティングを設定することで解消するものなので、そのままpushしております。