### PR TITLE
バリデーションを追加

### DIFF
--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,7 +1,15 @@
 class Movie < ApplicationRecord
   with_options presence: true do
-    validates :genru
+    validates :genre
     validates :title
     validates :url
   end
+  enum genre: {
+    invisible: 0,
+    basic: 1,
+    git: 2,
+    ruby: 3,
+    rails: 4,
+    php: 5
+  }
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,2 +1,7 @@
 class Movie < ApplicationRecord
+  with_options presence: true do
+    validates :genru
+    validates :title
+    validates :url
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,7 +1,15 @@
 class Text < ApplicationRecord
   with_options presence: true do
-    validates :genru
+    validates :genre
     validates :title
     validates :content
   end
+  enum genre: {
+    invisible: 0,
+    basic: 1,
+    git: 2,
+    ruby: 3,
+    rails: 4,
+    php: 5
+  }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,2 +1,7 @@
 class Text < ApplicationRecord
+  with_options presence: true do
+    validates :genru
+    validates :title
+    validates :content
+  end
 end


### PR DESCRIPTION
close #6

## 実装内容

- 「タスク4」で作成した2種類のモデルの各カラムにからデータが入らないようにバリデーションを追加
  - `with_options`を使用

- `Text`,`Movie` モデルの `genre` カラムを「列挙型」に設定

```ruby
enum genre: {
  invisible: 0,
  basic: 1,
  git: 2,
  ruby: 3,
  rails: 4,
  php: 5
 }
```

## 参考資料

- [【やんばるエキスパート教材】列挙型(enum)とセレクトボックス](https://www.yanbaru-code.com/texts/351)

## チェックリスト

- [x] ターミナルで「空のデータが入らないこと」を確認
- [x] ターミナルで「列挙型の設定ができていること」を確認
- [x] `rubocop -a` を実行
