### PR TITLE
フラッシュの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,3 +27,12 @@
 .mw-xl {
   max-width: 1200px;
 }
+
+/*・フラッシュ・*/
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |flash_type, msg| %>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">x</a>
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
       <%= render 'layouts/header' %>
     </header>
     <main>
+      <%= render 'layouts/flash' %>
       <div class="base-container <%= max_width %>">
         <%= yield %>
       </div>


### PR DESCRIPTION
close #15 

## 実装内容

- フラッシュの表示機能
  - ナビバー同様，横幅一杯とする（mainタグの開始タグすぐ下）
  - 直接application.html.erbに書き込まず，部分テンプレート app/views/layouts/_flash.html.erb を作成して読み込む

- フラッシュの背景色を設定
  - notice は alert-success, alert は alert-danger に設定

## 参考資料

- [【公式】Bootstrap（Alerts）](https://getbootstrap.jp/docs/4.5/components/alerts/)
- [【やんばるエキスパート教材】メッセージ投稿アプリ その3）](https://www.yanbaru-code.com/texts/271)

## チェックリスト

- [x] ログイン時・ログアウト時にフラッシュが表示されることを確認