### PR TITLE
教材のCSVインポート機能を実装

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,7 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+require "import_csv"
 
 email = "test@example.com"
 password = "password"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,3 +14,8 @@ User.find_or_create_by!(email: email) do |user|
   user.password = password
   puts "ユーザーの初期データインポートに成功しました。"
 end
+
+# texts, movies テーブルを再生成（関連付くテーブルを含む）
+%w[texts movies].each do |table_name|
+  ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,3 +19,6 @@ end
 %w[texts movies].each do |table_name|
   ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
 end
+
+ImportCsv.text_data
+ImportCsv.movie_data

--- a/lib/import_csv.rb
+++ b/lib/import_csv.rb
@@ -1,0 +1,27 @@
+require "csv"
+
+class ImportCsv
+  def self.import(path)
+    list = []
+    CSV.foreach(path, headers: true) do |row|
+      list << row.to_h
+    end
+    list
+  end
+
+  def self.text_data
+    list = import("db/csv_data/text_data.csv")
+
+    puts "テキスト教材のインポート処理を開始"
+    Text.create!(list)
+    puts "インポート完了"
+  end
+
+  def self.movie_data
+    list = import("db/csv_data/movie_data.csv")
+
+    puts "動画教材のインポート処理を開始"
+    Movie.create!(list)
+    puts "インポート完了"
+  end
+end


### PR DESCRIPTION
close #12

## 実装内容

-  教材のCSVインポート機能を実装
   -  libディレクトリに`import_csv.rb`を作成
   -  CSVデータをインポートするクラスメソッドを追加
   -  CSVデータをtextsテーブルに保存するクラスメソッドを追加
   -  CSVデータをmoviesテーブルに保存するクラスメソッドを追加
-  `db/seeds.rb`にCSVデータを投入する処理を追加
   - テキスト教材CSVをtexts テーブルにデータを投入する処理
   - 動画教材CSVをmovies テーブルにデータを投入する処理
-  `rails db:seed`を実行してテキスト教材・動画教材のデータを投入

## チェックリスト
- [x] `rails c`で教材データが入っていることを確認
- [x] `rubocop -a` を実行
