### PR TITLE
表示名の設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "2.7.3"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "devise"
 gem "devise-i18n"
+gem "enum_help"
 gem "jbuilder", "~> 2.7"
 gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.10.0)
       devise (>= 4.8.0)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.15.3)
     globalid (0.4.2)
@@ -244,6 +246,7 @@ DEPENDENCIES
   byebug
   devise
   devise-i18n
+  enum_help
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,0 +1,12 @@
+ja:
+  enums:
+    movie:
+      genre: &genre
+        invisible: 非表示
+        basic: Basic
+        git: Git
+        ruby: Ruby
+        rails: Ruby on Rails
+        php: PHP
+    text:
+      genre: *genre


### PR DESCRIPTION
close #13

## 実装内容

- `enum-help`を追加
- `texts` , `movies` テーブルの `genre` に対応する表示名を `config/locales/enums.ja.yml` に追加
  - YAMLのアンカー (`&`) , エイリアス (`*`) を利用して重複を回避
  - 「表示名」は、「動作確認」の箇所に記載している通りに設定

## 参考資料

- [【やんばるエキスパート教材】列挙型(enum)とセレクトボックス](https://www.yanbaru-code.com/texts/351)

## チェックリスト

- [x] 以下を実行し、教材データが入っていることを確認
```shell
rails c

#Railsコンソール起動後
Text.genres_i18n
#=> {"inbisible"=>"非表示", "basic"=>"Basic", "git"=>"Git", "ruby"=>"Ruby", "rails"=>"Ruby on Rails", "php"=>"PHP"}

Movie.genres_i18n
#=> {"inbisible"=>"非表示", "basic"=>"Basic", "git"=>"Git", "ruby"=>"Ruby", "rails"=>"Ruby on Rails", "php"=>"PHP"}