### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,0 +1,3 @@
+.card {
+  height: 370px;
+}

--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,3 +1,0 @@
-.card {
-  height: 370px;
-}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,3 +1,5 @@
 class MoviesController < ApplicationController
-  def index; end
+  def index
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+  end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,0 +1,12 @@
+module MoviesHelper
+  def embed_youtube(_url)
+    tag.iframe(
+      width: 560,
+      height: 315,
+      src: url,
+      frameborder: 0,
+      allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
+      allowfullscreen: true
+    )
+  end
+end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,5 +1,5 @@
 module MoviesHelper
-  def embed_youtube(_url)
+  def embed_youtube(url)
     tag.iframe(
       width: 560,
       height: 315,

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -12,4 +12,5 @@ class Movie < ApplicationRecord
     rails: 4,
     php: 5
   }
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 end

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,4 +1,4 @@
-<div class="col-12 col-md-6 col-lg-4">
+<div class="card-box col-12 col-md-6 col-lg-4">
   <div class="card border-dark mb-3">
     <div class="card-header p-0">
       <div class="embed-responsive embed-responsive-16by9">
@@ -7,7 +7,7 @@
     </div>
     <div class="card-body text-dark movie-body">
       <a class="btn btn-secondary btn-block mb-1" href="#">視聴済みにする</a>
-      <p class="card-text movie-title mt-3 mb-3">Lv.<%= movie.id %> : <%= movie.title %></p>
+      <p class="card-text movie-title mt-3 mb-3">Lv.<%= movie_counter + 1 %> : <%= movie.title %></p>
     </div>
   </div>
 </div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,0 +1,17 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-12 col-md-6 col-lg-4">
+      <div class="card border-dark mb-3">
+        <div class="card-header p-0">
+          <div class="embed-responsive embed-responsive-16by90">
+            <iframe width="560" height="315" src= movie.url frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="allowfullscreen"></iframe>
+          </div>
+        </div>
+        <div class="card-body text-dark movie-body">
+          <a class="btn btn-primary btn-block" href="#">視聴済みにする</a>
+          <p class="card-text movie-title"><%= movie.title %></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,17 +1,13 @@
-<div class="container-fluid">
-  <div class="row">
-    <div class="col-12 col-md-6 col-lg-4">
-      <div class="card border-dark mb-3">
-        <div class="card-header p-0">
-          <div class="embed-responsive embed-responsive-16by90">
-            <iframe width="560" height="315" src= movie.url frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="allowfullscreen"></iframe>
-          </div>
-        </div>
-        <div class="card-body text-dark movie-body">
-          <a class="btn btn-primary btn-block" href="#">視聴済みにする</a>
-          <p class="card-text movie-title"><%= movie.title %></p>
-        </div>
+<div class="col-12 col-md-6 col-lg-4">
+  <div class="card border-dark mb-3">
+    <div class="card-header p-0">
+      <div class="embed-responsive embed-responsive-16by9">
+        <%= embed_youtube(movie.url)%>
       </div>
+    </div>
+    <div class="card-body text-dark movie-body">
+      <a class="btn btn-secondary btn-block mb-1" href="#">視聴済みにする</a>
+      <p class="card-text movie-title mt-3 mb-3">Lv.<%= movie.id %> : <%= movie.title %></p>
     </div>
   </div>
 </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,1 +1,4 @@
-
+<h1 class="text-page-title text-center mt-2 mb-4">Ruby/Rails動画</h1>
+<div class= "row">
+  <%= render partial: "movie", collection: @movies %>
+</div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,8 +1,6 @@
 <div class ="contents-title text-center">
   <h1>Ruby/Rails 動画</h1>
 </div>
-<div class="container-fluid">
-  <div class= "row">
-    <%= render partial: "movie", collection: @movies %>
-  </div>
+<div class= "row m-2">
+  <%= render partial: "movie", collection: @movies %>
 </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,6 @@
-<h1 class="text-page-title text-center mt-2 mb-4">Ruby/Rails動画</h1>
+<div class ="contents-title text-center">
+  <h1>Ruby/Rails 動画</h1>
+</div>
 <div class= "row">
   <%= render partial: "movie", collection: @movies %>
 </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,6 +1,8 @@
 <div class ="contents-title text-center">
   <h1>Ruby/Rails 動画</h1>
 </div>
-<div class= "row">
-  <%= render partial: "movie", collection: @movies %>
+<div class="container-fluid">
+  <div class= "row">
+    <%= render partial: "movie", collection: @movies %>
+  </div>
 </div>


### PR DESCRIPTION
close #18

## 実装内容

- `app/models/movie.rb` に以下を定義
```ruby
RAILS_GENRE_LIST = %w[basic git ruby rails]
```

- Rails動画教材の一覧ページを作成
  - 表示するジャンルは `Movie::RAILS_GENRE_LIST` に制限
  - Bootstrapの `Cards`や `Grid System` を用いて下図のようなスタイルとする
  - `each` を使わず「コレクションをレンダリング」を利用
  - 各動画にレベル表示を挿入
  - カードの下側部分に `height` を指定して揃える
  - 動画教材ページでしか利用しないスタイルは `app/assets/stylesheets/movies.scss` を作成し、記載
  - 広告は未実装
  - ページネーションは別タスクとする
  - 「視聴済みボタン」はボタンの配置のみとする

![image](https://user-images.githubusercontent.com/83042016/127428291-b11c51ac-63ac-49b5-86f7-08fe48e45564.png)
![image](https://user-images.githubusercontent.com/83042016/127428347-0ff0b230-fcff-4db5-8bd3-e3b663cfc195.png)
![image](https://user-images.githubusercontent.com/83042016/127428360-1d6e2f39-5385-418d-8896-cd6fa7803030.png)


## 参考資料
- [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)
- [【公式】Embeds](https://getbootstrap.com/docs/4.5/utilities/embed/)
- [【やんばるエキスパート教材】YouTube動画の投稿](https://www.yanbaru-code.com/texts/349)

## チェックリスト

- [x] 画像のようにレスポンシブ対応できているかどうかを確認
- [x] カードの高さが一定になっているか確認
- [x] PHPの動画教材が表示されていないことを確認
- [x] `rubocop -a` を実行


## 備考
各動画にレベル表示を入れる箇所が、イレギュラーな書き方となってしまっているかもしれません。
