### PR TITLE
動画教材ページのジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,9 +1,9 @@
 class MoviesController < ApplicationController
   def index
-    if params[:genre] == "php"
-      @movies = Movie.where(genre: Movie::PHP_GENRE_LIST)
-    else
-      @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
-    end
+    @movies = if params[:genre] == "php"
+                Movie.where(genre: Movie::PHP_GENRE_LIST)
+              else
+                Movie.where(genre: Movie::RAILS_GENRE_LIST)
+              end
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,9 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    if params[:genre] == 5
+      @movies = Movie.where(gerne: Movie::PHP_GENRE_LIST)
+    else
+      @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    end
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,7 +1,7 @@
 class MoviesController < ApplicationController
   def index
-    if params[:genre] == 5
-      @movies = Movie.where(gerne: Movie::PHP_GENRE_LIST)
+    if params[:genre] == "php"
+      @movies = Movie.where(genre: Movie::PHP_GENRE_LIST)
     else
       @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def movie_title
+    if params[:genre] == "php"
+      "PHP 動画"
+    else
+      "Ruby/Rails 動画"
+    end
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -10,7 +10,8 @@ class Movie < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5
+    php: 5,
   }
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  PHP_GENRE_LIST = %w[php].freeze
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -10,7 +10,7 @@ class Movie < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5,
+    php: 5
   }
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
   PHP_GENRE_LIST = %w[php].freeze

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,9 +1,5 @@
 <div class ="contents-title text-center">
-  <% if params[:genre] == "php" %>
-    <h1>PHP 動画</h1>
-  <% else %>
-    <h1>Ruby/Rails 動画</h1>
-  <% end %>
+  <h1><%= movie_title %></h1>
 </div>
 <div class= "row m-2">
   <%= render partial: "movie", collection: @movies %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,5 +1,9 @@
 <div class ="contents-title text-center">
-  <h1>Ruby/Rails 動画</h1>
+  <% if params[:genre] == "php" %>
+    <h1>PHP 動画</h1>
+  <% else %>
+    <h1>Ruby/Rails 動画</h1>
+  <% end %>
 </div>
 <div class= "row m-2">
   <%= render partial: "movie", collection: @movies %>


### PR DESCRIPTION
close #21

## 実装内容

- PHP動画教材ページで「PHPの動画教材のみ」が表示されるように修正

- 「Ruby/Rails動画教材ページ」のタイトルは「Ruby/Rails 動画」，「PHP動画教材ページ」のタイトルは「PHP 動画」とする

## 確認内容

- 「Ruby/Rails動画教材」に「PHP動画」が含まれていないことを確認
- 「PHP動画教材」に「PHP動画」のみが表示されていることを確認
- クエリパラメータ ```?genre=php``` を ```php``` 以外に変更してアクセスした際は「Ruby/Rails動画教材」が表示されることを確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行