### PR TITLE
ゲストログイン機能を実装

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,8 @@
+module Users
+  class SessionsController < Devise::SessionsController
+    def guest_sign_in
+      sign_in User.guest
+      redirect_to root_path, notice: "ゲストユーザーとしてログインしました"
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
+
+  def self.guest
+    find_or_create_by!(email: "test@example.com") do |user|
+      user.password = SecureRandom.urlsafe_base64
+    end
+  end
 end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,12 @@
 <h1><%= t('.resend_confirmation_instructions') %></h1>
-
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= bootstrap_devise_error_messages! %>
-
   <div class="form-group">
     <%= f.label :email %>
     <%= f.email_field :email, autofocus: true, autocomplete: 'email', value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: 'form-control' %>
   </div>
-
   <div class="form-group">
     <%= f.submit t('.resend_confirmation_instructions'), class: 'btn btn-primary' %>
   </div>
 <% end %>
-
 <%= render 'devise/shared/links' %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,4 +21,4 @@
   </div>
 <% end %>
 <hr class="my-5">
-<%= link_to "ログイン", new_user_session_path, class: "btn btn-block btn-secondary" %>
+<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -21,4 +21,5 @@
   </div>
 <% end %>
 <hr class="my-5">
-<%= link_to "アカウント登録", new_user_registration_path, class: "btn btn-block btn-secondary" %>
+<%= link_to "ゲストログイン (閲覧用)", users_guest_sign_in_path, method: :post, class: "btn btn-block btn-success" %>
+<%= link_to "アカウント登録", new_user_registration_path, class: "btn btn-block btn-secondary mt-4" %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,24 +1,20 @@
 <div class="form-group">
   <%- if controller_name != 'sessions' %>
-    <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
+    <%= link_to t(".sign_in"), new_session_path(resource_name), class: "btn btn-block btn-primary" %><br />
+    <%= link_to "ゲストログイン (閲覧用)", users_guest_sign_in_path, method: :post, class: "btn btn-block btn-success mt4" %>
   <% end -%>
-
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
     <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
   <% end -%>
-
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
     <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
   <% end -%>
-
   <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
     <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
   <% end -%>
-
   <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
     <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
   <% end -%>
-
   <%- if devise_mapping.omniauthable? %>
     <%- resource_class.omniauth_providers.each do |provider| %>
       <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %><br />

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -31,6 +31,7 @@
       <% else %>
         <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
         <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "nav-item nav-link active" %>
       <% end %>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   devise_for :users
+  devise_scope :user do
+    post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
+  end
   root "texts#index"
   resources :texts, only: [:index, :show]
   resources :movies, only: [:index]


### PR DESCRIPTION
close #22

## 実装内容

- ゲストログイン機能を実装
  - 「ナビバー」と「ログイン・新規登録のページ(`app/views/shared/_links.html.erb`を利用)に配置
  - ゲストユーザーのメールアドレスは `test@example.com` とする
  - ゲストユーザーを削除・更新されるケースへの対応は未実施
  - パスワード再設定機能も未実装

## 参考資料

- [【やんばるエキスパート教材】ゲストログイン機能の実装](https://www.yanbaru-code.com/texts/392)

## チェックリスト

- [x] ゲストログインのリンク・ボタンからログインできることを確認
