### PR TITLE
動画教材のページネーションを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "rouge"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
+gem "kaminari"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "devise-bootstrap-views"
 gem "devise-i18n"
 gem "enum_help"
 gem "jbuilder", "~> 2.7"
+gem "kaminari"
 gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"
 gem "rails", "~> 6.1.1"
@@ -19,7 +20,6 @@ gem "rouge"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
-gem "kaminari"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,7 @@ DEPENDENCIES
   devise-i18n
   enum_help
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   pg (~> 1.1)
   pre-commit

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,3 +48,8 @@ body {
 .alert-alert {
   @extend .alert-danger;
 }
+
+// ページネーション
+.pagination {
+  justify-content: center;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,6 @@
 class MoviesController < ApplicationController
+  PER_PAGE = 12
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -7,7 +7,7 @@
     </div>
     <div class="card-body text-dark movie-body">
       <a class="btn btn-secondary btn-block mb-1" href="#">視聴済みにする</a>
-      <p class="card-text movie-title mt-3 mb-3">Lv.<%= movie_counter + 1 %> : <%= movie.title %></p>
+      <p class="card-text movie-title mt-3 mb-3">Lv.<%= movie_counter + 1 + @movies.offset_value %> : <%= movie.title %></p>
     </div>
   </div>
 </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -4,3 +4,4 @@
 <div class= "row m-2">
   <%= render partial: "movie", collection: @movies %>
 </div>
+<%= paginate @movies %>


### PR DESCRIPTION
close #24

## 実装内容
-  Gem `kaminari`をインストール
-  動画教材ページにページネーションを実装

## 確認内容
-  Ruby/Rails動画 に ページネーション が付いていることを確認
-  動画の1ページの最大表示数が 12 であることを確認
-  2ページ目のレベル開始が 13 であることを確認
-  ページネーションに Bootstrap のスタイルが適用され，中央寄せになっていることを確認

## 参考文献
-  [【やんばるエキスパート教材】検索機能(Ransack)
](https://www.yanbaru-code.com/texts/221)
-  [ kaminari徹底入門 ](https://qiita.com/nysalor/items/77b9d6bc5baa41ea01f3)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] 確認内容で記載した実装条件を満たすこと
- [x] `rubocop -a` を実行
