### PR TITLE
テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,11 @@
 class TextsController < ApplicationController
+  PER_PAGE = 12
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = if params[:genre] == "php"
+               Text.where(genre: Text::PHP_GENRE_LIST).page(params[:page]).per(PER_PAGE)
+             else
+               Text.where(genre: Text::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
+             end
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,12 @@ module ApplicationHelper
       "Ruby/Rails 動画"
     end
   end
+
+  def text_movie
+    if params[:genre] == "php"
+      "PHP テキスト教材"
+    else
+      "Ruby/Railsテキスト教材"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,7 +17,7 @@ module ApplicationHelper
     end
   end
 
-  def text_movie
+  def text_title
     if params[:genre] == "php"
       "PHP テキスト教材"
     else

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -13,4 +13,5 @@ class Text < ApplicationRecord
     php: 5
   }
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  PHP_GENRE_LIST = %w[php].freeze
 end

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-page-title text-center mt-2 mb-4">Ruby/Railsテキスト教材</h1>
+<h1 class="text-page-title text-center mt-2 mb-4"><%= text_title %></h1>
 <div class="row">
   <%= render partial: "text", collection: @texts %>
 </div>


### PR DESCRIPTION
close #23

## 実装内容

- PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正
- 「PHPテキスト教材ページ」のタイトルを「PHP テキスト教材」に修正

## チェックリスト

- [x] 「Ruby/Railsテキスト教材」に「PHPテキスト教材」が含まれていないことを確認
- [x] 「PHPテキスト教材」に「PHPテキスト教材」のみが表示されていることを確認
- [x] クエリパラメータ ?genre=php を php 以外に変更してアクセスした際は「Ruby/Railsテキスト教材」が表示されることを確認
