### PR TITLE
テキスト教材の読破済み機能

### DIFF
--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,11 +1,11 @@
 class ReadProgressesController < ApplicationController
   def create
-    current_user.read_progresses.create!(text_id: params[:text_id])
-    redirect_to request.referer
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.create!(text_id: @text.id)
   end
 
   def destroy
-    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
-    redirect_to request.referer
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.find_by(text_id: @text.id).destroy!
   end
 end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,0 +1,11 @@
+class ReadProgressesController < ApplicationController
+  def create
+    current_user.read_progresses.create!(text_id: params[:text_id])
+    redirect_to request.referer
+  end
+
+  def destroy
+    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
+    redirect_to request.referer
+  end
+end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.includes(:read_progresses).where(genre: Text::RAILS_GENRE_LIST)
   end
 
   def show

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,0 +1,4 @@
+class ReadProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :text
+end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -3,7 +3,7 @@ class ReadProgress < ApplicationRecord
   belongs_to :text
 
   validates :user_id, uniqueness: {
-                        scope: :text_id,
-                        message: "は同じテキスト教材を2回以上読破済みにはできません。",
-                      }
+    scope: :text_id,
+    message: "は同じテキスト教材を2回以上読破済みにはできません。"
+  }
 end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,4 +1,9 @@
 class ReadProgress < ApplicationRecord
   belongs_to :user
   belongs_to :text
+
+  validates :user_id, uniqueness: {
+                        scope: :text_id,
+                        message: "は同じテキスト教材を2回以上読破済みにはできません。",
+                      }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -18,6 +18,6 @@ class Text < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
   def read_by?(user)
-    read_progresses.exists?(user_id: user.id)
+    read_progresses.any? { |read_progress| read_progress.user_id == user.id }
   end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -16,4 +16,8 @@ class Text < ApplicationRecord
     php: 5,
   }
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+
+  def read_by?(user)
+    read_progresses.exists?(user_id: user.id)
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -4,13 +4,16 @@ class Text < ApplicationRecord
     validates :title
     validates :content
   end
+
+  has_many :read_progresses, dependent: :destroy
+
   enum genre: {
     invisible: 0,
     basic: 1,
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5
+    php: 5,
   }
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -13,7 +13,7 @@ class Text < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5,
+    php: 5
   }
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
 
+  has_many :read_progresses, dependent: :destroy
+
   def self.guest
     find_or_create_by!(email: "test@example.com") do |user|
       user.password = SecureRandom.urlsafe_base64

--- a/app/views/read_progresses/create.js.erb
+++ b/app/views/read_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("text-<%= @text.id %>").innerHTML = "<%= j render("texts/disread_progress", text: @text) %>"

--- a/app/views/read_progresses/destroy.js.erb
+++ b/app/views/read_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("text-<%= @text.id %>").innerHTML = "<%= j render("texts/read_progress", text: @text) %>"

--- a/app/views/texts/_disread_progress.html.erb
+++ b/app/views/texts/_disread_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, class: "btn btn-block btn-primary" %>

--- a/app/views/texts/_disread_progress.html.erb
+++ b/app/views/texts/_disread_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, class: "btn btn-block btn-primary" %>
+<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, remote: true, class: "btn btn-block btn-primary" %>

--- a/app/views/texts/_read_progress.html.erb
+++ b/app/views/texts/_read_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, class: "btn btn-block btn-secondary" %>
+<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, remote: true, class: "btn btn-block btn-secondary" %>

--- a/app/views/texts/_read_progress.html.erb
+++ b/app/views/texts/_read_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, class: "btn btn-block btn-secondary" %>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -5,7 +5,7 @@
         <img class="img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="スダンダードコースのイメージ画像">
       </div>
       <div class="card-body text-dark">
-        <p>
+        <p id="text-<%= text.id %>">
           <% if text.read_by?(current_user) %>
             <%= render "disread_progress", text: text %>
           <% else %>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -5,9 +5,13 @@
         <img class="img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="スダンダードコースのイメージ画像">
       </div>
       <div class="card-body text-dark">
-        <div class="read-through-box mb-1">
-          <button class="btn btn-block btn-secondary">読破済みにする</button>
-        </div>
+        <p>
+          <% if text.read_by?(current_user) %>
+            <%= render "disread_progress", text: text %>
+          <% else %>
+            <%= render "read_progress", text: text %>
+          <% end %>
+        </p>
         <p class="card-title mt-3 mb-3"><%= text.title %></p>
         <p class="card-text">【<%= text.genre_i18n %>】</p>
       </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       movie: 動画教材
       text: テキスト教材
+      read_progress: 読破済み
     attributes:
       movie:
         genre: ジャンル
@@ -12,6 +13,9 @@ ja:
         genre: ジャンル
         title: タイトル
         content: 内容
+      read_progress:
+        user: ユーザー
+        text: テキスト教材
   attributes:
     id: ID
     namespace: 名前空間

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end
   root "texts#index"
-  resources :texts, only: [:index, :show]
+  resources :texts, only: [:index, :show] do
+    resource :read_progresses, only: [:create, :destroy]
+  end
   resources :movies, only: [:index]
 end

--- a/db/migrate/20210811080544_create_read_progresses.rb
+++ b/db/migrate/20210811080544_create_read_progresses.rb
@@ -1,0 +1,10 @@
+class CreateReadProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :read_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :text, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210811080544_create_read_progresses.rb
+++ b/db/migrate/20210811080544_create_read_progresses.rb
@@ -6,5 +6,6 @@ class CreateReadProgresses < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+    add_index :read_progresses, [:user_id, :text_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_26_220012) do
+ActiveRecord::Schema.define(version: 2021_08_11_080544) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2021_07_26_220012) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "read_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "text_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["text_id"], name: "index_read_progresses_on_text_id"
+    t.index ["user_id", "text_id"], name: "index_read_progresses_on_user_id_and_text_id", unique: true
+    t.index ["user_id"], name: "index_read_progresses_on_user_id"
+  end
+
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
@@ -66,4 +76,6 @@ ActiveRecord::Schema.define(version: 2021_07_26_220012) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "read_progresses", "texts"
+  add_foreign_key "read_progresses", "users"
 end


### PR DESCRIPTION
close #25

## 実装内容

- 読破済み機能に使用する `ReadProgress` モデルを作成

- テキスト教材一覧ページに読破済み機能を実装

## 確認内容

- 以下を確認
```
rails c -s

# Railsコンソール起動後
user = User.first
text, text2 = Text.limit(2)
ReadProgress.delete_all

user.read_progresses.create!(text_id: text.id)
user.read_progresses.create!(text_id: text2.id)

ReadProgress.count
#=> 2

text.read_progresses.create!(user_id: user.id)
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: Userは同じテキスト教材を2回以上読破済みにはできません

ReadProgress.create!
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: ユーザーを入力してください, テキスト教材を入力してください
```
## 参考資料（必要があれば）

- [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
- [x] テキスト教材一覧ページの読破済み機能が動作していることを確認